### PR TITLE
Enable fixed background on mobile

### DIFF
--- a/CCSB.css
+++ b/CCSB.css
@@ -182,6 +182,8 @@ html { background-color: #8B5E3C; }
     background: hsl(var(--primary)) url('https://i.ibb.co/4wBH7S3R/0ea4ea193a4f-dosmasenlamesa-2-z.jpg') center center no-repeat;
     background-size: cover;
     background-attachment: fixed;
+    background-position: center;
+    will-change: transform; /* optimización */
     display: flex;
     align-items: center;
     justify-content: center;
@@ -190,7 +192,6 @@ html { background-color: #8B5E3C; }
 
 @media (max-width: 1024px) {
     .hero-section {
-        background-attachment: scroll; /* evita bug de pantalla negra en móviles */
         background-color: #111; /* fallback paint */
         min-height: 100dvh; /* llenar pantalla en móvil */
     }

--- a/JAVAB.js
+++ b/JAVAB.js
@@ -403,3 +403,12 @@ function showToast(title, message) {
         toast.classList.remove('show');
     }, 4000);
 }
+
+// Parallax en móviles
+document.addEventListener("scroll", () => {
+  const hero = document.querySelector(".hero-section");
+  if (hero) {
+    let offset = window.scrollY * 0.5; // velocidad parallax
+    hero.style.backgroundPositionY = `${offset}px`;
+  }
+});


### PR DESCRIPTION
Enable `background-attachment: fixed` for the hero section on mobile devices.

iOS/Android browsers ignore `background-attachment: fixed`, so a JavaScript scroll listener is added to simulate the parallax effect on mobile, and the conflicting `background-attachment: scroll` rule for mobile is removed.

---
<a href="https://cursor.com/background-agent?bcId=bc-7aca9d4f-fefe-4d31-a604-121bb0df12ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7aca9d4f-fefe-4d31-a604-121bb0df12ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

